### PR TITLE
Add ws2_32 library to linking of dapcxx

### DIFF
--- a/dap/CMakeLists.txt
+++ b/dap/CMakeLists.txt
@@ -7,5 +7,11 @@ FILE(GLOB SRCS "*.cpp")
 find_package(wxWidgets COMPONENTS adv aui base core xml xrc net stc richtext REQUIRED)
 include( "${wxWidgets_USE_FILE}" )
 
+set( ADDITIONAL_LIBRARIES "" )
+
+if(MINGW)
+set(ADDITIONAL_LIBRARIES "-lws2_32")
+endif()
+
 add_library(dapcxx SHARED ${SRCS})
-target_link_libraries(dapcxx ${wxWidgets_LIBRARIES})
+target_link_libraries(dapcxx ${wxWidgets_LIBRARIES} ${ADDITIONAL_LIBRARIES})


### PR DESCRIPTION
I am trying to update the MSys2 mingw PKGBUILD to version 16.4.0 and I got an linking error.
This is my guess on the proper solution.