### PR TITLE
Change to `cmake_minimum_required(VERSION 3.5)` (from 3.0) 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(wxdap)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)

--- a/dap/CMakeLists.txt
+++ b/dap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(dapcxx)
 
 include_directories(${CMAKE_SOURCE_DIR})

--- a/dbgcli/CMakeLists.txt
+++ b/dbgcli/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(dap_demo)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(daptests)
 
 include_directories(${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
to avoid cmake warning:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```
